### PR TITLE
Correctly lookup twemoji with multiple unicode characters

### DIFF
--- a/packages/emoji-favicon-webpack-plugin/index.js
+++ b/packages/emoji-favicon-webpack-plugin/index.js
@@ -18,7 +18,7 @@ async function generatePngs(options) {
     return render(emoji, sizes);
   }
 
-  const unicode = emojiUnicode(emoji);
+  const unicode = emojiUnicode(emoji).replace(/\s+/g, '-');
   const svg = await fs.readFile(
     require.resolve(`twemoji/2/svg/${unicode}.svg`)
   );


### PR DESCRIPTION
Previously when using an emoji with multiple unicode characters (such as 👨‍💻), emojiUnicode will return the unicode with spaces - `1f468 200d 1f4bb`. As twemoji uses `-` instead of spaces (for example `twemoji/2/svg/1f468-200d-1f4bb.svg`) the lookup will fail. When running in gatsby-plugin-emoji-favicon the following error occurs:
![image](https://user-images.githubusercontent.com/1362580/82738244-17b4c200-9d2e-11ea-98e9-2a8ebe96eb73.png)

This change replaces spaces returned from emojiUnicode with `-` so the correct filepath will now be used: `twemoji/2/svg/1f468-200d-1f4bb.svg` instead of `twemoji/2/svg/1f468 200d 1f4bb.svg`.